### PR TITLE
fix: Update date of birth field to be nullable across requests

### DIFF
--- a/app/Http/Requests/Member/StoreMemberRequest.php
+++ b/app/Http/Requests/Member/StoreMemberRequest.php
@@ -32,7 +32,7 @@ final class StoreMemberRequest extends FormRequest
             'email' => ['required', 'email', Rule::unique('members')],
             'phone' => ['required', 'phone', Rule::unique('members')],
             'gender' => ['required', 'string', Rule::enum(Gender::class)],
-            'dob' => ['required', 'date:Y-m-d'],
+            'dob' => ['nullable', 'date:Y-m-d'],
             'civil_status' => ['required', 'string', Rule::enum(CivilStatus::class)],
             'skills' => ['array'],
             'skills.*' => ['string'],

--- a/app/Http/Requests/Member/UpdateMemberRequest.php
+++ b/app/Http/Requests/Member/UpdateMemberRequest.php
@@ -35,7 +35,7 @@ final class UpdateMemberRequest extends FormRequest
             'email' => ['required', 'email', Rule::unique('members')->ignore($this->member->id)],
             'phone' => ['required', 'phone', Rule::unique('members')->ignore($this->member->id)],
             'gender' => ['required', 'string', Rule::enum(Gender::class)],
-            'dob' => ['required', 'date:Y-m-d'],
+            'dob' => ['nullable', 'date:Y-m-d'],
             'civil_status' => ['required', 'string', Rule::enum(CivilStatus::class)],
             'skills' => ['array'],
             'skills.*' => ['string'],

--- a/app/Http/Resources/Member/MemberResource.php
+++ b/app/Http/Resources/Member/MemberResource.php
@@ -29,7 +29,7 @@ final class MemberResource extends JsonResource
             'email' => $this->email,
             'phone' => $this->phone,
             'gender' => $this->gender->value,
-            'dob' => $this->dob->format('Y-m-d'),
+            'dob' => $this->dob?->format('Y-m-d'),
             'civilStatus' => $this->civil_status->value,
             'skills' => TagRelationshipResource::collection($this->tagsWithType(TagType::SKILL->value)),
             'skillsCount' => $this->whenCounted('skills', $this->tagsWithType(TagType::SKILL->value)->count()),

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -23,7 +23,7 @@ use Spatie\Tags\HasTags;
  * @property-read string $email
  * @property-read string $phone
  * @property-read Gender $gender
- * @property-read CarbonImmutable $dob
+ * @property-read CarbonImmutable|null $dob
  * @property-read CivilStatus $civil_status
  * @property-read CarbonImmutable|null $deleted_at
  * @property-read CarbonImmutable $created_at

--- a/database/migrations/tenant/2025_04_04_195205_create_members_table.php
+++ b/database/migrations/tenant/2025_04_04_195205_create_members_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->string('phone')->unique();
             $table->string('gender');
-            $table->date('dob');
+            $table->date('dob')->nullable();
             $table->string('civil_status');
             $table->timestamps();
             $table->softDeletes();

--- a/resources/js/pages/members/create.tsx
+++ b/resources/js/pages/members/create.tsx
@@ -82,7 +82,7 @@ export default function Create({ genders, civilStatuses, skills, categories }: C
             <PhoneField required label="Phone" value={data.phone} onChange={(value) => setData('phone', value)} error={errors.phone} />
           </FieldsGrid>
 
-          <DateField required label="Date of Birth" value={data.dob} onChange={(value) => setData('dob', value)} error={errors.dob} />
+          <DateField label="Date of Birth" value={data.dob} onChange={(value) => setData('dob', value)} error={errors.dob} />
 
           <FieldsGrid>
             <SelectField

--- a/resources/js/pages/members/edit.tsx
+++ b/resources/js/pages/members/edit.tsx
@@ -46,7 +46,7 @@ export default function Edit({ member, genders, civilStatuses, skills, categorie
     last_name: member.lastName,
     email: member.email,
     phone: member.phone,
-    dob: member.dob,
+    dob: member.dob ?? '',
     gender: member.gender,
     civil_status: member.civilStatus,
     skills: convertTagsToMultiselectOptions(member.skills),
@@ -83,7 +83,7 @@ export default function Edit({ member, genders, civilStatuses, skills, categorie
             <PhoneField required label="Phone" value={data.phone} onChange={(value) => setData('phone', value)} error={errors.phone} />
           </FieldsGrid>
 
-          <DateField required label="Date of Birth" value={data.dob} onChange={(value) => setData('dob', value)} error={errors.dob} />
+          <DateField label="Date of Birth" value={data.dob} onChange={(value) => setData('dob', value)} error={errors.dob} />
 
           <FieldsGrid>
             <SelectField

--- a/resources/js/types/models/member.d.ts
+++ b/resources/js/types/models/member.d.ts
@@ -11,7 +11,7 @@ export interface Member {
   email: string;
   phone: string;
   gender: Gender;
-  dob: string;
+  dob: string | null;
   civilStatus: CivilStatus;
   skills: TagRelationship[];
   skillsCount?: number;


### PR DESCRIPTION
Closes #23 
This pull request introduces changes to make the `dob` (date of birth) field optional across the application. The updates include adjustments to validation rules, database schema, API resources, and frontend forms to handle nullable `dob` values gracefully.

### Backend Changes:

* **Validation Rules:**
  - Updated the `dob` field in `StoreMemberRequest` and `UpdateMemberRequest` to be nullable instead of required. (`app/Http/Requests/Member/StoreMemberRequest.php`, `app/Http/Requests/Member/UpdateMemberRequest.php`) [[1]](diffhunk://#diff-b3d5daf48d201c559a862aaa2187e87add6d76c43e69d7bc05c6880bfaf413dfL35-R35) [[2]](diffhunk://#diff-df3db1cf1f2bae3894b5da0ae3e0a46227e0542e0c09f65cae353ffe9de350c3L38-R38)

* **Database Schema:**
  - Modified the `dob` column in the `members` table to allow null values. (`database/migrations/tenant/2025_04_04_195205_create_members_table.php`)

* **API Resource:**
  - Updated `MemberResource` to handle nullable `dob` by using the safe navigation operator (`?->`) when formatting the date. (`app/Http/Resources/Member/MemberResource.php`)

* **Model Property:**
  - Changed the `dob` property in the `Member` model to allow null values. (`app/Models/Member.php`)

### Frontend Changes:

* **Create and Edit Forms:**
  - Removed the `required` attribute from the `DateField` for `dob` in both the create and edit member pages. (`resources/js/pages/members/create.tsx`, `resources/js/pages/members/edit.tsx`) [[1]](diffhunk://#diff-92bff3cc0d03b4153cdd36d08e920df5d4dd5da9c83731b78b62c0f9b840182eL85-R85) [[2]](diffhunk://#diff-0507ef2a62035e007853e013d701347532f38f89601ea87fc15c5c0cdfa02d43L86-R86)
  - Updated the `dob` field in the edit form to default to an empty string if the value is null. (`resources/js/pages/members/edit.tsx`)