### PR TITLE
feat: Implement Expense Type management with CRUD functionality and U…

### DIFF
--- a/app/Http/Controllers/ExpenseTypeController.php
+++ b/app/Http/Controllers/ExpenseTypeController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\FlashMessageKey;
+use App\Http\Requests\Code\StoreExpenseTypeRequest;
+use App\Http\Requests\Code\UpdateExpenseTypeRequest;
+use App\Http\Resources\Codes\ExpenseTypeResource;
+use App\Models\ExpenseType;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class ExpenseTypeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): Response
+    {
+        $expenseTypes = ExpenseType::latest()->get();
+
+        return Inertia::render('codes/expenseTypes/index', [
+            'expenseTypes' => ExpenseTypeResource::collection($expenseTypes),
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreExpenseTypeRequest $request): RedirectResponse
+    {
+        ExpenseType::create($request->validated());
+
+        return to_route('codes.expenseTypes.index')->with(FlashMessageKey::SUCCESS->value,
+            __('flash.message.created', ['model' => 'Expense type']));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateExpenseTypeRequest $request, ExpenseType $expenseType): RedirectResponse
+    {
+        $expenseType->update($request->validated());
+
+        return to_route('codes.expenseTypes.index')->with(FlashMessageKey::SUCCESS->value,
+            __('flash.message.updated', ['model' => 'Expense type']));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(ExpenseType $expenseType): RedirectResponse
+    {
+        $expenseType->delete();
+
+        return to_route('codes.expenseTypes.index')->with(FlashMessageKey::SUCCESS->value,
+            __('flash.message.deleted', ['model' => 'Expense type']));
+    }
+}

--- a/app/Http/Requests/Code/StoreExpenseTypeRequest.php
+++ b/app/Http/Requests/Code/StoreExpenseTypeRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Code;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class StoreExpenseTypeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('expense_types')],
+        ];
+    }
+}

--- a/app/Http/Requests/Code/UpdateExpenseTypeRequest.php
+++ b/app/Http/Requests/Code/UpdateExpenseTypeRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Code;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * @property-read \App\Models\ExpenseType $expenseType
+ */
+final class UpdateExpenseTypeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('expense_types')->ignore($this->expenseType->id)],
+        ];
+    }
+}

--- a/app/Http/Resources/Codes/ExpenseTypeResource.php
+++ b/app/Http/Resources/Codes/ExpenseTypeResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Codes;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\ExpenseType
+ */
+final class ExpenseTypeResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'createdAt' => $this->created_at->format('Y-m-d H:i:s'),
+            'updatedAt' => $this->updated_at->format('Y-m-d H:i:s'),
+        ];
+    }
+}

--- a/app/Models/ExpenseType.php
+++ b/app/Models/ExpenseType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property-read int $id
+ * @property-read string $name
+ * @property-read CarbonImmutable $created_at
+ * @property-read CarbonImmutable $updated_at
+ */
+final class ExpenseType extends Model
+{
+    /** @use HasFactory<\Database\Factories\ExpenseTypeFactory> */
+    use HasFactory;
+}

--- a/database/factories/ExpenseTypeFactory.php
+++ b/database/factories/ExpenseTypeFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ExpenseType>
+ */
+final class ExpenseTypeFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/migrations/tenant/2025_04_29_182330_create_expense_types_table.php
+++ b/database/migrations/tenant/2025_04_29_182330_create_expense_types_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('expense_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('expense_type');
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -65,6 +65,11 @@ const codesNavItems: NavItem[] = [
     href: route('codes.offeringTypes.index'),
     icon: LayoutGridIcon,
   },
+  {
+    title: 'Expense types',
+    href: route('codes.expenseTypes.index'),
+    icon: LayoutGridIcon,
+  },
 ];
 
 const footerNavItems: NavItem[] = [

--- a/resources/js/pages/codes/expenseTypes/components/ExpenseTypeForm.tsx
+++ b/resources/js/pages/codes/expenseTypes/components/ExpenseTypeForm.tsx
@@ -1,0 +1,52 @@
+import { InputField } from '@/components/forms/inputs/InputField';
+import { SubmitButton } from '@/components/forms/SubmitButton';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import type { ExpenseType } from '@/types/models/expense-type';
+import { useForm } from '@inertiajs/react';
+import { useLaravelReactI18n } from 'laravel-react-i18n';
+import { useState } from 'react';
+
+export function ExpenseTypeForm({ expenseType, children }: { expenseType?: ExpenseType; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const { t } = useLaravelReactI18n();
+  const { data, setData, post, put, errors, processing } = useForm({
+    name: expenseType?.name ?? '',
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (expenseType) {
+      put(route('codes.expenseTypes.update', expenseType.id), {
+        onSuccess: () => {
+          setOpen(false);
+        },
+      });
+    } else {
+      post(route('codes.expenseTypes.store'), {
+        onSuccess: () => {
+          setOpen(false);
+          setData({ name: '' });
+        },
+      });
+    }
+  }
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{expenseType ? t('Edit Expense Type') : t('Add Expense Type')}</DialogTitle>
+          <DialogDescription hidden></DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <InputField required label={t('Name')} value={data.name} onChange={(value) => setData('name', value)} error={errors.name} />
+
+          <div className="flex justify-end">
+            <SubmitButton isSubmitting={processing}>{t('Save')}</SubmitButton>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/pages/codes/expenseTypes/includes/columns.tsx
+++ b/resources/js/pages/codes/expenseTypes/includes/columns.tsx
@@ -1,0 +1,69 @@
+import { DataTableColumnHeader } from '@/components/custom-ui/datatable/DataTableColumnHeader';
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import useConfirmationStore from '@/stores/confirmationStore';
+import type { ExpenseType } from '@/types/models/expense-type';
+import { router } from '@inertiajs/react';
+import { type ColumnDef } from '@tanstack/react-table';
+import { useLaravelReactI18n } from 'laravel-react-i18n';
+import { Edit2Icon, MoreHorizontalIcon, Trash2Icon } from 'lucide-react';
+import { ExpenseTypeForm } from '../components/ExpenseTypeForm';
+
+export const columns: ColumnDef<ExpenseType>[] = [
+  {
+    enableHiding: false,
+    header: ({ column }) => <DataTableColumnHeader column={column} center={false} title="Name" />,
+    accessorKey: 'name',
+  },
+  {
+    id: 'actions',
+    enableHiding: false,
+    enableSorting: false,
+    size: 0,
+    cell: function CellComponent({ row }) {
+      const { t } = useLaravelReactI18n();
+      const { openConfirmation } = useConfirmationStore();
+      const expenseType = row.original;
+
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm">
+              <MoreHorizontalIcon />
+              <span className="sr-only">{t('Actions')}</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <ExpenseTypeForm expenseType={expenseType}>
+              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                <Edit2Icon className="size-3" />
+                <span>{t('Edit')}</span>
+              </DropdownMenuItem>
+            </ExpenseTypeForm>
+
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={() => {
+                openConfirmation({
+                  title: t('Are you sure you want to delete this expense type?'),
+                  description: t('This action cannot be undone.'),
+                  actionLabel: t('Delete'),
+                  actionVariant: 'destructive',
+                  cancelLabel: t('Cancel'),
+                  onAction: () => {
+                    router.delete(route('codes.expenseTypes.destroy', expenseType.id), {
+                      preserveScroll: true,
+                    });
+                  },
+                });
+              }}
+            >
+              <Trash2Icon className="size-3" />
+              <span>{t('Delete')}</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    },
+  },
+];

--- a/resources/js/pages/codes/expenseTypes/index.tsx
+++ b/resources/js/pages/codes/expenseTypes/index.tsx
@@ -1,0 +1,26 @@
+import { DataTable } from '@/components/custom-ui/datatable/data-table';
+import { PageTitle } from '@/components/PageTitle';
+import { Button } from '@/components/ui/button';
+import AppLayout from '@/layouts/app-layout';
+import type { ExpenseType } from '@/types/models/expense-type';
+import { useLaravelReactI18n } from 'laravel-react-i18n';
+import { ExpenseTypeForm } from './components/ExpenseTypeForm';
+import { columns } from './includes/columns';
+
+export default function ExpenseTypesIndex({ expenseTypes }: { expenseTypes: ExpenseType[] }) {
+  const { t } = useLaravelReactI18n();
+  return (
+    <AppLayout title={t('Expense Types')} breadcrumbs={[{ title: t('Expense Types') }]}>
+      <PageTitle>{t('Expense Types')}</PageTitle>
+      <DataTable
+        headerButton={
+          <ExpenseTypeForm>
+            <Button>{t('Add Expense Type')}</Button>
+          </ExpenseTypeForm>
+        }
+        data={expenseTypes}
+        columns={columns}
+      />
+    </AppLayout>
+  );
+}

--- a/resources/js/types/models/expense-type.d.ts
+++ b/resources/js/types/models/expense-type.d.ts
@@ -1,4 +1,4 @@
-export interface OfferingType {
+export interface ExpenseType {
   id: number;
   name: string;
   createdAt: string;


### PR DESCRIPTION
This pull request introduces a new "Expense Types" feature, including backend and frontend implementations to manage expense types in the application. The feature includes a controller, request validation, resource transformation, database migration, and frontend components for listing, creating, editing, and deleting expense types.

### Backend Implementation

* **Controller and Resource Management**:
  - Added `ExpenseTypeController` to handle CRUD operations for expense types, including listing, creating, updating, and deleting.
  - Introduced `ExpenseTypeResource` for transforming expense type data into JSON format.

* **Validation**:
  - Added `StoreExpenseTypeRequest` for validating new expense types, ensuring the name is required, unique, and within character limits.
  - Added `UpdateExpenseTypeRequest` for validating updates to existing expense types, with rules to ignore the current record's ID for uniqueness checks.

* **Database Changes**:
  - Created a migration to define the `expense_types` table with `id`, `name`, and timestamp fields.
  - Added the `ExpenseType` model to represent the `expense_types` table in the application.
  - Added a factory for generating `ExpenseType` instances for testing or seeding.

### Frontend Implementation

* **UI Components**:
  - Added `ExpenseTypeForm` for creating and editing expense types in a modal dialog.
  - Added `columns.tsx` to define table columns, including actions for editing and deleting expense types.
  - Created the `ExpenseTypesIndex` page to display a table of expense types with options to add, edit, or delete.

* **Navigation**:
  - Updated the sidebar navigation to include a link to the "Expense Types" page.