### PR TITLE
Drop unique constraint on phone field in members table

### DIFF
--- a/database/migrations/tenant/2026_06_01_162843_drop_unique_phone_from_members_table.php
+++ b/database/migrations/tenant/2026_06_01_162843_drop_unique_phone_from_members_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('members', function (Blueprint $table): void {
+            $table->dropUnique(['phone']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('members', function (Blueprint $table): void {
+            $table->unique('phone');
+        });
+    }
+};


### PR DESCRIPTION
Remove the unique constraint on the phone field in the members table to allow duplicate phone numbers. This change facilitates better data entry flexibility.